### PR TITLE
JSON endpoint for translated messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": ">=7.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "ext-json": "*",
         "composer/package-versions-deprecated": "1.11.99.1",
         "doctrine/annotations": "^1.0",
         "phpdocumentor/reflection-docblock": "^5.2",

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -14,7 +14,8 @@ use Symfony\Component\Routing\Annotation\Route;
 class DefaultController extends AbstractController
 {
     /**
-     * @Route("/{route}", requirements={"route"=".+"}, defaults={"route"=""})
+     * @Route("/{route}", requirements={"route"=".+"}, defaults={"route"=""}, priority=-1)
+     * @todo route priority is temporarily set to -1 as it's extremely greedy because of the {route} parameter.
      */
     public function index(string $route, W3CApi $w3CApi, CraftCmsApi $craftApi): Response
     {

--- a/src/Controller/JsonController.php
+++ b/src/Controller/JsonController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class JsonController extends AbstractController
+{
+    /**
+     * Returns a JSON response of all translated messages corresponding to the request language
+     *
+     * @Route("/translated-messages")
+     */
+    public function translatedMessages(Request $request, TranslatorInterface $translator): JsonResponse
+    {
+        if ($translator instanceof TranslatorBagInterface) {
+            $locale = $request->getLocale();
+
+            foreach (['messages', 'w3c_website_templates_bundle'] as $domain) {
+                $catalogues[$domain] = $translator->getCatalogue($locale)->all($domain);
+            }
+
+            return $this->json($catalogues);
+        }
+
+        throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+}

--- a/tests/Controller/JsonControllerTest.php
+++ b/tests/Controller/JsonControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class JsonControllerTest extends WebTestCase
+{
+    /**
+     * @dataProvider languageProvider
+     */
+    public function testTranslatedMessages(string $prefix): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', $prefix . '/translated-messages');
+        $messages = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertArrayHasKey('messages', $messages);
+        $this->assertArrayHasKey('w3c_website_templates_bundle', $messages);
+    }
+
+    public function languageProvider(): array
+    {
+        return [
+            ['prefix' => ''],
+            ['prefix' => '/ja']
+        ];
+    }
+}


### PR DESCRIPTION
This new endpoint returns JSON containing all translated messages for a specific language (retrieved from the URL prefix)