### PR TITLE
Fetch cross links from Craft

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7131,12 +7131,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/w3c/w3c-website-templates-bundle.git",
-                "reference": "1ba2ccc42bde68f0fe2136120ea7dd81e74687f8"
+                "reference": "af9abe510e743b72aa4e4dfa51ffeff7ae4919dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/w3c/w3c-website-templates-bundle/zipball/1ba2ccc42bde68f0fe2136120ea7dd81e74687f8",
-                "reference": "1ba2ccc42bde68f0fe2136120ea7dd81e74687f8",
+                "url": "https://api.github.com/repos/w3c/w3c-website-templates-bundle/zipball/af9abe510e743b72aa4e4dfa51ffeff7ae4919dd",
+                "reference": "af9abe510e743b72aa4e4dfa51ffeff7ae4919dd",
                 "shasum": ""
             },
             "require": {
@@ -7161,7 +7161,7 @@
                 "issues": "https://github.com/w3c/w3c-website-templates-bundle/issues",
                 "source": "https://github.com/w3c/w3c-website-templates-bundle/tree/main"
             },
-            "time": "2021-08-04T15:59:04+00:00"
+            "time": "2021-08-05T17:06:07+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Query/CraftCMS/Page.php
+++ b/src/Query/CraftCMS/Page.php
@@ -32,7 +32,7 @@ class Page extends GraphQLQuery
         $this->setGraphQLFromFile(__DIR__ . '/graphql/page.graphql')
             ->addFragmentFromFile(__DIR__ . '/graphql/fragments/defaultFlexibleComponents.graphql')
             ->addFragmentFromFile(__DIR__ . '/graphql/fragments/landingFlexibleComponents.graphql')
-            ->addFragmentFromFile(__DIR__ . '/graphql/fragments/youMayAlsoLikeRelatedEntries.graphql')
+            ->addFragmentFromFile(__DIR__. '/graphql/fragments/thumbnailImage.graphql')
             ->addFragmentFromFile(__DIR__ . '/graphql/fragments/seoData.graphql')
             ->setRootPropertyPath('[entry]')
 
@@ -47,5 +47,4 @@ class Page extends GraphQLQuery
             //->setCacheTags($uri)
         ;
     }
-
 }

--- a/src/Query/CraftCMS/Page.php
+++ b/src/Query/CraftCMS/Page.php
@@ -32,7 +32,7 @@ class Page extends GraphQLQuery
         $this->setGraphQLFromFile(__DIR__ . '/graphql/page.graphql')
             ->addFragmentFromFile(__DIR__ . '/graphql/fragments/defaultFlexibleComponents.graphql')
             ->addFragmentFromFile(__DIR__ . '/graphql/fragments/landingFlexibleComponents.graphql')
-            ->addFragmentFromFile(__DIR__. '/graphql/fragments/thumbnailImage.graphql')
+            ->addFragmentFromFile(__DIR__ . '/graphql/fragments/thumbnailImage.graphql')
             ->addFragmentFromFile(__DIR__ . '/graphql/fragments/seoData.graphql')
             ->setRootPropertyPath('[entry]')
 

--- a/src/Query/CraftCMS/YouMayAlsoLikeRelatedEntries.php
+++ b/src/Query/CraftCMS/YouMayAlsoLikeRelatedEntries.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Query\CraftCMS;
+
+use App\Service\CraftCMS;
+use Strata\Data\Cache\CacheLifetime;
+use Strata\Data\Exception\GraphQLQueryException;
+use Strata\Data\Mapper\MapArray;
+use Strata\Data\Query\GraphQLQuery;
+use Strata\Data\Transform\Data\CallableData;
+
+/**
+ * Get global navigation
+ */
+class YouMayAlsoLikeRelatedEntries extends GraphQLQuery
+{
+
+    /**
+     * Set up query
+     *
+     * @param int    $siteId        Site ID to generate global navigation for
+     * @param string $uri
+     * @param int    $cacheLifetime Cache lifetime to store HTTP response for, defaults to 24 hours
+     *
+     * @throws GraphQLQueryException
+     */
+    public function __construct(int $siteId, string $uri, int $cacheLifetime = CacheLifetime::HOUR)
+    {
+        parent::__construct(__DIR__ . '/graphql/youMayAlsoLikeRelatedEntries.graphql');
+        $this
+            ->addFragmentFromFile(__DIR__ . '/graphql/fragments/youMayAlsoLikeRelatedEntries.graphql')
+            ->addFragmentFromFile(__DIR__ . '/graphql/fragments/thumbnailImage.graphql')
+            ->setRootPropertyPath('[entry]')
+
+            // Set page URI to retrieve navigation for
+            ->addVariable('uri', $uri)
+
+            // Set site ID to retrieve navigation for
+            ->addVariable('siteId', $siteId)
+
+            // Cache page response
+            ->enableCache($cacheLifetime)
+            //->setCacheTags(['global'])
+        ;
+    }
+
+    public function getRequiredDataProviderClass(): string
+    {
+        return CraftCMS::class;
+    }
+
+    public function transformText(?string $text, ?string $entryText): ?string
+    {
+        return $text ?: ($entryText ?: null);
+    }
+
+    public function transformImage(?array $entry)
+    {
+        if (array_key_exists('contentEntry', $entry)) {
+            $entry = $entry['contentEntry'][0];
+        }
+
+        if (array_key_exists('thumbnailImage', $entry) && count($entry['thumbnailImage']) > 0) {
+            if (array_key_exists('thumbnailAltText', $entry)) {
+                return array_merge($entry['thumbnailImage'][0], ['alt' => $entry['thumbnailAltText']]);
+            }
+
+            return $entry['thumbnailImage'][0];
+        }
+
+        return null;
+    }
+
+    public function getMapping()
+    {
+        return [
+            '[title]' => '[youMayAlsoLikeTitle]',
+            '[text]'  => '[youMayAlsoLikeSectionIntroduction]',
+            '[links]' => new MapArray(
+                '[youMayAlsoLikeRelatedEntries]',
+                [
+                    '[title]'    => new CallableData([$this, 'transformText'], '[title]', '[contentEntry][0][title]'),
+                    '[url]'      => new CallableData([$this, 'transformText'], '[url]', '[contentEntry][0][url]'),
+                    '[category]' => new CallableData(
+                        [$this, 'transformText'],
+                        '[category]',
+                        '[contentEntry][0][category]'
+                    ),
+                    '[text]'     => new CallableData([$this, 'transformText'], '[text]', '[contentEntry][0][text]'),
+                    '[img]'      => new CallableData(
+                        [$this, 'transformImage']
+                    )
+
+                ]
+            )
+        ];
+    }
+}

--- a/src/Query/CraftCMS/YouMayAlsoLikeRelatedEntries.php
+++ b/src/Query/CraftCMS/YouMayAlsoLikeRelatedEntries.php
@@ -51,11 +51,6 @@ class YouMayAlsoLikeRelatedEntries extends GraphQLQuery
         return CraftCMS::class;
     }
 
-    public function transformText(?string $text, ?string $entryText): ?string
-    {
-        return $text ?: ($entryText ?: null);
-    }
-
     public function transformImage(?array $entry)
     {
         if (array_key_exists('contentEntry', $entry)) {
@@ -81,18 +76,11 @@ class YouMayAlsoLikeRelatedEntries extends GraphQLQuery
             '[links]' => new MapArray(
                 '[youMayAlsoLikeRelatedEntries]',
                 [
-                    '[title]'    => new CallableData([$this, 'transformText'], '[title]', '[contentEntry][0][title]'),
-                    '[url]'      => new CallableData([$this, 'transformText'], '[url]', '[contentEntry][0][url]'),
-                    '[category]' => new CallableData(
-                        [$this, 'transformText'],
-                        '[category]',
-                        '[contentEntry][0][category]'
-                    ),
-                    '[text]'     => new CallableData([$this, 'transformText'], '[text]', '[contentEntry][0][text]'),
-                    '[img]'      => new CallableData(
-                        [$this, 'transformImage']
-                    )
-
+                    '[title]'    => ['[title]', '[contentEntry][0][title]'],
+                    '[url]'      => ['[url]', '[contentEntry][0][url]'],
+                    '[category]' => ['[category]', '[contentEntry][0][category]'],
+                    '[text]'     => ['[text]', '[contentEntry][0][text]'],
+                    '[img]'      => new CallableData([$this, 'transformImage'])
                 ]
             )
         ];

--- a/src/Query/CraftCMS/graphql/fragments/thumbnailImage.graphql
+++ b/src/Query/CraftCMS/graphql/fragments/thumbnailImage.graphql
@@ -1,0 +1,5 @@
+fragment thumbnailImage on AssetInterface {
+    src: url
+    title
+    srcset(sizes: ["360", "920", "1520"])
+}

--- a/src/Query/CraftCMS/graphql/fragments/youMayAlsoLikeRelatedEntries.graphql
+++ b/src/Query/CraftCMS/graphql/fragments/youMayAlsoLikeRelatedEntries.graphql
@@ -1,24 +1,82 @@
 fragment youMayAlsoLikeRelatedEntries on youMayAlsoLikeRelatedEntries_MatrixField {
     ... on youMayAlsoLikeRelatedEntries_contentFromTheCms_BlockType {
-        typeHandle
         contentEntry {
+            category: typeHandle
             title
-            uri
+            url: uri
+            ... on blogPosts_default_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                    }
+                thumbnailAltText
+            }
+            ... on pages_landingPage_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
+            ... on pressReleases_default_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
+            ... on newsArticles_default_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
+            ... on pages_default_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
+            ... on events_default_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
+            ... on businessEcosystems_default_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
+            ... on events_external_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
+            ... on homepage_homepage_Entry {
+                text: excerpt
+                thumbnailImage {
+                    ...thumbnailImage
+                }
+                thumbnailAltText
+            }
         }
     }
     ... on youMayAlsoLikeRelatedEntries_contentFromAnotherSource_BlockType {
-        typeHandle
-        resourceUrl
+        url: resourceUrl
         thumbnailImage {
-            url
-            mimeType
-            height
-            width
-            size
+            ...thumbnailImage
         }
         thumbnailAltText
-        resourceTitle
-        excerpt
-        typeOfContent
+        title: resourceTitle
+        text: excerpt
+        category: typeOfContent
     }
 }

--- a/src/Query/CraftCMS/graphql/page.graphql
+++ b/src/Query/CraftCMS/graphql/page.graphql
@@ -35,12 +35,6 @@ query Page($uri: [String], $siteId: [QueryArgument]) {
             defaultFlexibleComponents(orderBy: "sortOrder") {
                 ...defaultFlexibleComponents
             }
-            displayYouMayAlsoLikeListing
-            youMayAlsoLikeTitle
-            youMayAlsoLikeSectionIntroduction
-            youMayAlsoLikeRelatedEntries {
-                ...youMayAlsoLikeRelatedEntries
-            }
             excerpt
             thumbnailImage {
                 id
@@ -63,15 +57,9 @@ query Page($uri: [String], $siteId: [QueryArgument]) {
             landingFlexibleComponents(orderBy: "sortOrder") {
                 ...landingFlexibleComponents
             }
-            displayYouMayAlsoLikeListing
-            youMayAlsoLikeTitle
-            youMayAlsoLikeSectionIntroduction
-            youMayAlsoLikeRelatedEntries {
-                ...youMayAlsoLikeRelatedEntries
-            }
             excerpt
             thumbnailImage {
-                id
+                ...thumbnailImage
             }
             thumbnailAltText
             seoOptions {

--- a/src/Query/CraftCMS/graphql/youMayAlsoLikeRelatedEntries.graphql
+++ b/src/Query/CraftCMS/graphql/youMayAlsoLikeRelatedEntries.graphql
@@ -1,0 +1,18 @@
+query YouMayAlsoLike($uri: [String], $siteId: [QueryArgument]) {
+    entry(uri: $uri, siteId: $siteId, displayYouMayAlsoLikeListing: true) {
+        ... on pages_default_Entry {
+            youMayAlsoLikeTitle
+            youMayAlsoLikeSectionIntroduction
+            youMayAlsoLikeRelatedEntries {
+                ...youMayAlsoLikeRelatedEntries
+            }
+        }
+        ... on pages_landingPage_Entry {
+            youMayAlsoLikeTitle
+            youMayAlsoLikeSectionIntroduction
+            youMayAlsoLikeRelatedEntries {
+                ...youMayAlsoLikeRelatedEntries
+            }
+        }
+    }
+}

--- a/templates/debug/page.html.twig
+++ b/templates/debug/page.html.twig
@@ -9,69 +9,6 @@
     '#design-principles': 'Design principles',
     '#vision': 'Vision'
 } %}
-{% set crosslinks = {
-    title: 'Section heading for these teasers',
-    text: 'Highlights from across our News, Press Releases and Blog',
-    links: [
-        {
-            'url': '../page.html',
-            'title': 'W3C starts web payments standards work',
-            'text': 'New working group launched to make payments easier and more secure.',
-            'category': 'News',
-            'img': {
-            'src': asset('images/temp-developers-920.jpg', 'main'),
-            'srcset':
-            asset('images/temp-developers-360.jpg', 'main') ~ ' 360w, ' ~
-            asset('images/temp-developers-580.jpg', 'main') ~ ' 580w, ' ~
-            asset('images/temp-developers-700.jpg', 'main') ~ ' 700w, ' ~
-            asset('images/temp-developers-920.jpg', 'main') ~ ' 920w, ' ~
-            asset('images/temp-developers-1520.jpg', 'main') ~ ' 1520w',
-            'sizes': '(min-width: 64em) 33vw, (min-width: 48em) 50vw, 100vw',
-            'alt': 'A Macbook screen with code, as seen from over the developer\'s shoulder'
-        }
-        },
-        {
-            'url': '../page.html',
-            'title': 'Work begins on extensions to WCAG 2.0',
-            'text': 'A new charter for the Working Group was formally approved by W3C.',
-            'category': 'Blog',
-            'img': {
-            'src': asset('images/temp-developers-920.jpg', 'main'),
-            'srcset':
-            asset('images/temp-developers-360.jpg', 'main') ~ ' 360w, ' ~
-            asset('images/temp-developers-580.jpg', 'main') ~ ' 580w, ' ~
-            asset('images/temp-developers-700.jpg', 'main') ~ ' 700w, ' ~
-            asset('images/temp-developers-920.jpg', 'main') ~ ' 920w, ' ~
-            asset('images/temp-developers-1520.jpg', 'main') ~ ' 1520w',
-            'sizes': '(min-width: 64em) 33vw, (min-width: 48em) 50vw, 100vw',
-            'alt': 'A Macbook screen with code, as seen from over the developer\'s shoulder'
-        }
-        },
-        {
-            'url': '../page.html',
-            'title': 'Contributions to ISOC report on mobile internet',
-            'text': 'The HTML5Apps team contributed significantly to the report.',
-            'category': 'Press release'
-        },
-        {
-            'url': '../page.html',
-            'title': 'W3C starts web payments standards work',
-            'text': 'New working group launched to make payments easier and more secure.',
-            'category': 'News',
-            'img': {
-            'src': asset('images/temp-developers-920.jpg', 'main'),
-            'srcset':
-            asset('images/temp-developers-360.jpg', 'main') ~ ' 360w, ' ~
-            asset('images/temp-developers-580.jpg', 'main') ~ ' 580w, ' ~
-            asset('images/temp-developers-700.jpg', 'main') ~ ' 700w, ' ~
-            asset('images/temp-developers-920.jpg', 'main') ~ ' 920w, ' ~
-            asset('images/temp-developers-1520.jpg', 'main') ~ ' 1520w',
-            'sizes': '(min-width: 64em) 33vw, (min-width: 48em) 50vw, 100vw',
-            'alt': 'A Macbook screen with code, as seen from over the developer\'s shoulder'
-        }
-        }
-    ]
-} %}
 
 {% block body %}
     {% embed '@W3CWebsiteTemplates/components/text.html.twig' %}


### PR DESCRIPTION
Instead of fetching cross links as part of the Page query, they now have a dedicated query, which makes them a bit easier to manage.

I'm not a big fan of the YouMayAlsoLikeRelatedEntries::getMapping() method but I don't know if it can be improved.