### PR TITLE
assets now use cdn by default (can be overridden in .env.local)

### DIFF
--- a/.env
+++ b/.env
@@ -36,5 +36,5 @@ W3C_API_URL=https://api.w3.org/
 CRAFTCMS_API_READ_TOKEN=
 CRAFTCMS_API_PUBLISH_TOKEN=
 W3C_API_KEY=
-ASSETS_BASE_URL=https://cdn.w3.org/templates/website-2021/
+ASSETS_BASE_URL=https://cdn.w3.org/assets/website-2021/
 

--- a/.env
+++ b/.env
@@ -36,5 +36,5 @@ W3C_API_URL=https://api.w3.org/
 CRAFTCMS_API_READ_TOKEN=
 CRAFTCMS_API_PUBLISH_TOKEN=
 W3C_API_KEY=
-ASSETS_BASE_URL=https://cdn.w3.org/assets/website-2021/
+ASSETS_WEBSITE_2021=https://cdn.w3.org/assets/website-2021/
 

--- a/.env
+++ b/.env
@@ -36,4 +36,5 @@ W3C_API_URL=https://api.w3.org/
 CRAFTCMS_API_READ_TOKEN=
 CRAFTCMS_API_PUBLISH_TOKEN=
 W3C_API_KEY=
+ASSETS_BASE_URL=https://cdn.w3.org/templates/website-2021/
 

--- a/config/packages/assets.yaml
+++ b/config/packages/assets.yaml
@@ -2,4 +2,4 @@ framework:
     assets:
         packages:
             website-2021:
-                base_urls: '%app.app_url%/bundles/w3cwebsitetemplates/dist/assets/'
+                base_urls: '%env(ASSETS_BASE_URL)%'

--- a/config/packages/assets.yaml
+++ b/config/packages/assets.yaml
@@ -2,4 +2,4 @@ framework:
     assets:
         packages:
             website-2021:
-                base_urls: '%env(ASSETS_BASE_URL)%'
+                base_urls: '%env(ASSETS_WEBSITE_2021)%'


### PR DESCRIPTION
There's a bug with SVG sprites (see basecamp).