### PR TITLE
Remove PHP-FPM reload since no longer necessary on remote server

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -23,7 +23,6 @@ set('disk_space_filesystem', '/var/www');
 // W3C AWS config
 set('http_user', 'www-data');
 set('remote_user', 'studio24');
-set('php_fpm_version', '8.4');
 
 /**
  * 3. Hosts
@@ -57,6 +56,3 @@ host('staging')
  *
  * Any custom deployment tasks to run
  */
-
-// PHP-FPM reload
-after('deploy', 'php-fpm:reload');


### PR DESCRIPTION
Removed PHP-FPM reload since @jean-gui added this to webserver config:

```
opcache.revalidate_path=1
```

Re: https://deployer.org/docs/8.x/avoid-php-fpm-reloading#fix-for-apache